### PR TITLE
Fix DTO naming: Change DTO to Dto line 14

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/01-rest-api-and-spring-data-jpa/02-jpa-relations/exercises/04-dtos.md
+++ b/01-rest-api-and-spring-data-jpa/02-jpa-relations/exercises/04-dtos.md
@@ -11,7 +11,7 @@ To address these issues, we can use Data Transfer Objects (DTOs). DTOs are simpl
 
 ## Step 1: Creating DTOs
 
-Create a new package `dto` in the `ek.osnb.jpa.orders` package. Inside the `dto` package, create two records: `OrderDTO` and `OrderLineDTO`.
+Create a new package `dto` in the `ek.osnb.jpa.orders` package. Inside the `dto` package, create two records: `OrderDto` and `OrderLineDto`.
 
 ```java
 public record OrderDto(Long id, LocalDate orderDate, String status, List<OrderLineDto> orderLines) {


### PR DESCRIPTION
Rettede OrderDTO til OrderDto og OrderLineDTO til OrderLineDto i øvelsen.

Dette var den nemmeste og korteste måde at løse potentielle navnekonflikter på.